### PR TITLE
Bitbake: easier to build w/ 2 threads/core (default remains 1)

### DIFF
--- a/conf/local.conf
+++ b/conf/local.conf
@@ -3,9 +3,9 @@ CONF_VERSION = "1"
 
 # additionally build a tar.gz image file (as needed for installing on SD)
 #IMAGE_FSTYPES = "jffs2 tar.gz"
-# speed up build by parallel building - usefull for multicore cpus
-#PARALLEL_MAKE = "-j 4"
-#BB_NUMBER_THREADS = "4"
+# Default is to run 1 thread/core. For an agressive build, uncomment these two lines.
+#PARALLEL_MAKE = "-j ${@oe.utils.cpu_count() * 2}"
+#BB_NUMBER_THREADS = "${@oe.utils.cpu_count() * 2}"
 # avoid multiple locales generation to speedup the build and save space, but keep at least en_US and en_GB here 
 # see LIBC_DEPENDENCIES in meta/conf/distro/include/tclibc-glibc.inc:
 #GLIBC_GENERATE_LOCALES = "en_US.UTF-8 en_GB.UTF-8 cs_CZ.UTF-8"


### PR DESCRIPTION
- Clarifies that Bitbake, by default, takes advantage of multiple CPUs.
- Makes it easier for devs getting started to configure an aggressive build

Open-WebOS-DCO-1.0-Signed-Off-By: Doug Reeder reeder.29@gmail.com
