### PR TITLE
bblayers.conf: Add meta-filesystems from meta-openembedded (required …

### DIFF
--- a/conf/bblayers.conf
+++ b/conf/bblayers.conf
@@ -23,6 +23,7 @@ BBLAYERS = " \
   ${TOPDIR}/meta-smartphone/meta-xiaomi \
   ${TOPDIR}/meta-smartphone/meta-android \
   ${TOPDIR}/meta-qt5 \
+  ${TOPDIR}/meta-openembedded/meta-filesystems \
   ${TOPDIR}/meta-openembedded/meta-networking \
   ${TOPDIR}/meta-openembedded/meta-python \
   ${TOPDIR}/meta-openembedded/meta-oe \


### PR DESCRIPTION
…for PDM)

Newly introduced PDM from webOS OSE requires various bits from meta-filesystems. Therefore add it here.

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>