### PR TITLE
webos-ports-setup: Add meta-arm and meta-rockchip

### DIFF
--- a/conf/bblayers.conf
+++ b/conf/bblayers.conf
@@ -24,6 +24,8 @@ BBLAYERS = " \
   ${TOPDIR}/meta-smartphone/meta-qualcomm-modems \
   ${TOPDIR}/meta-qt5 \
   ${TOPDIR}/meta-python2 \
+  ${TOPDIR}/meta-arm \
+  ${TOPDIR}/meta-rockchip \
   ${TOPDIR}/meta-openembedded/meta-filesystems \
   ${TOPDIR}/meta-openembedded/meta-networking \
   ${TOPDIR}/meta-openembedded/meta-python \

--- a/conf/layers.txt
+++ b/conf/layers.txt
@@ -8,3 +8,5 @@ meta-webos-ports,https://github.com/webOS-ports/meta-webos-ports.git,honister,HE
 meta-pine64-luneos,https://github.com/webOS-ports/meta-pine64-luneos.git,honister,HEAD
 meta-rpi-luneos,https://github.com/webOS-ports/meta-rpi-luneos.git,honister,02319176871adb58270f07fb7f1ed8e26f44c757
 meta-raspberrypi,https://github.com/agherzan/meta-raspberrypi.git,honister,378d4b6e7ba64b6a9a701457cc3780fa896ba5dc
+meta-arm,https://git.yoctoproject.org/meta-arm.git,honistor,HEAD
+meta-rockchip,https://git.yoctoproject.org/meta-rockchip.git,honister,HEAD

--- a/conf/layers.txt
+++ b/conf/layers.txt
@@ -8,5 +8,5 @@ meta-webos-ports,https://github.com/webOS-ports/meta-webos-ports.git,honister,HE
 meta-pine64-luneos,https://github.com/webOS-ports/meta-pine64-luneos.git,honister,HEAD
 meta-rpi-luneos,https://github.com/webOS-ports/meta-rpi-luneos.git,honister,02319176871adb58270f07fb7f1ed8e26f44c757
 meta-raspberrypi,https://github.com/agherzan/meta-raspberrypi.git,honister,378d4b6e7ba64b6a9a701457cc3780fa896ba5dc
-meta-arm,https://git.yoctoproject.org/meta-arm.git,honistor,HEAD
-meta-rockchip,https://git.yoctoproject.org/meta-rockchip.git,honister,HEAD
+meta-arm,https://git.yoctoproject.org/meta-arm.git,honistor,a834653374cb3485fe8c6561f254ce701b5b281e
+meta-rockchip,https://git.yoctoproject.org/meta-rockchip.git,master,17703ee37b46d15ec369588fbb86dde336df6028


### PR DESCRIPTION
For PinePhonePro we use parts from meta-rockchip, which requires meta-arm as well.

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>