### PR TITLE
conf/bblayers.conf: Add meta-smartphone/meta-google

### DIFF
--- a/conf/bblayers.conf
+++ b/conf/bblayers.conf
@@ -14,6 +14,7 @@ BBLAYERS = " \
   ${TOPDIR}/meta-pine64-luneos \
   ${TOPDIR}/meta-rpi-luneos \
   ${TOPDIR}/meta-raspberrypi \
+  ${TOPDIR}/meta-smartphone/meta-google \
   ${TOPDIR}/meta-smartphone/meta-hp \
   ${TOPDIR}/meta-smartphone/meta-huawei \
   ${TOPDIR}/meta-smartphone/meta-lg \


### PR DESCRIPTION
Add meta-google for Pixel 3A (Sargo/Bonito)

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>