### PR TITLE
bblayers.conf: Add meta-greentouch

### DIFF
--- a/conf/bblayers.conf
+++ b/conf/bblayers.conf
@@ -16,6 +16,7 @@ BBLAYERS = " \
   ${TOPDIR}/meta-rpi-luneos \
   ${TOPDIR}/meta-raspberrypi \
   ${TOPDIR}/meta-smartphone/meta-google \
+  ${TOPDIR}/meta-smartphone/meta-greentouch \
   ${TOPDIR}/meta-smartphone/meta-hp \
   ${TOPDIR}/meta-smartphone/meta-huawei \
   ${TOPDIR}/meta-smartphone/meta-lg \


### PR DESCRIPTION
To allow build of GreenTouch devices.

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>
