### PR TITLE
conf/layers.txt: Use latest revisions from meta-qt6 6.8.1

### DIFF
--- a/conf/layers.txt
+++ b/conf/layers.txt
@@ -1,7 +1,7 @@
 bitbake,https://github.com/openembedded/bitbake.git,2.8,f40a3a477d5241b697bf2fb030dd804c1ff5839f
 openembedded-core,https://github.com/openembedded/openembedded-core.git,scarthgap,92eea72a25e553c698bee9e3f551a5880bd4631c
 meta-openembedded,https://github.com/openembedded/meta-openembedded.git,scarthgap,5f9f741193f55bb4bb3c974e913d169dd23e40d3
-meta-qt6,https://code.qt.io/yocto/meta-qt6.git,6.7.2,d4ad3746864a815b9c42bed7f0f81e0471ca975f
+meta-qt6,https://code.qt.io/yocto/meta-qt6.git,6.8.1,f4ef1331f0cc49bd4aa1e1aace6dc7f000b9651e
 meta-clang,https://github.com/kraj/meta-clang.git,scarthgap,f002eb5ab051443e7b5fbc32a9505d63a67db7b6
 meta-smartphone,https://github.com/shr-distribution/meta-smartphone.git,scarthgap,HEAD
 meta-webos-ports,https://github.com/webOS-ports/meta-webos-ports.git,scarthgap,HEAD


### PR DESCRIPTION
meta-qt6: d4ad3746864a815b9c42bed7f0f81e0471ca975f..f4ef1331f0cc49bd4aa1e1aace6dc7f000b9651e f4ef133 Update submodule refs on '6.8.1' in yocto/meta-qt6 38cae6a Update submodule refs on '6.8.1' in yocto/meta-qt6 2358c62 Update submodule refs on '6.8.1' in yocto/meta-qt6 5f1af8c qt6: update licenses
66ef206 Update submodule refs on '6.8.1' in yocto/meta-qt6 5bf5b55 qt6: update licenses
c81bcff qt6: update licenses
f95f697 Update submodule refs on '6.8' in yocto/meta-qt6 b3e346d qttools: check available clang version
52c5c34 layer: add walnascar to layer series
3b2306f sdk: include staticdev packages by default de258ca pyside6: remove unneeded patching
3cef727 qtapplicationmanager: remove patch
91ef10c Update submodule refs on '6.8' in yocto/meta-qt6 0142dd8 readme: update release status
3163a99 qtpdf: workaround for wrong sbom file
91a2c3f Include SBOM files in -dev packages
0d0f454 qttools: fix another example tracking buildpaths 3aa3351 qtapplicationmanager: refresh patch
4267d2f Update submodule refs on '6.8' in yocto/meta-qt6 affcbb7 Remove webengine related GCC13 patch
98bb732 pyside6: remove buildpaths
510150e coin: add workaround for clang build
1486448 coin: build against styhead
7e15f2c qttools: remove buildpaths from the binaries 173bf9b ptest: skip buildpaths QA tests for ptest packages ce51849 qtapplicationmanager: fix contains reference to TMPDIR QA issues 6cf2e7f qtgrpc: fix reference to TMPDIR QA issues
b397bba Remove TMPDIR references from qmake files
ed91cc0 pyside6: include PySide6 recipes for Qt 6.8.1 586a6cb Update submodule refs on '6.8' in yocto/meta-qt6 82354cf Update submodule refs on '6.8' in yocto/meta-qt6 ade6783 Update submodule refs on '6.8' in yocto/meta-qt6 0ca353d Update submodule refs on '6.8' in yocto/meta-qt6 b374cf6 Bump version to 6.8.1
781bc5c Update submodule refs on '6.8' in yocto/meta-qt6 647dca1 Update submodule refs on '6.8' in yocto/meta-qt6 620c36b Webengine: fix zlib cmake option
d9e6ff2 Update submodule refs on '6.8' in yocto/meta-qt6 99679ae Add CTF tracing backend configure option
f106de7 qtpdf: Add dependency to webengine
96e8095 gcc-source: Only apply patch on GCC 13
ea3f10e qtwebengine: Add missing patch headers
acfa89a qtwebengine: Set DEBUG_LEVELFLAG to -g1
0b5d762 Update submodule refs on '6.8' in yocto/meta-qt6 5664699 Revert "qtwebengine: Add patch for cross-compilation error" 385b861 qtapplicationmanager: remove patch
d6f7dba Update submodule refs on '6.8' in yocto/meta-qt6 7d3da91 qtwebengine: Add patch for cross-compilation error 4874464 Do not build webnn with xnnpack (122-based) on yocto dca85f7 Fix cross compiler crash when compiling qtwebengine 65a233e qtwebengine: update chromium branch
06abb7a python3-qface: backport recipe from meta-oe master 2cfa653 qtapplicationmanager: update recipe
6c86d36 qt3d: update license
8b7c9a1 qmlcompilerplus: Update licenses
8ead4b0 qtdeviceutilities: update licenses
d1f9a24 qtwayland: update license
729e1fa qtshadertools: update license
639c232 qtshadertools: update licenses
6195b2e Update submodule refs on '6.8' in yocto/meta-qt6 b7dd88b qtpdf: add cups dependency
0e2daeb qtlocation: update licenses
084ec50 qt6-git.inc: Switch to 6.8 branch
a4530f4 Update submodule refs on '6.8' in yocto/meta-qt6 1ef5e7c Update submodule refs on 'dev' in yocto/meta-qt6 381b6c5 Update submodule refs on 'dev' in yocto/meta-qt6 d43b178 layer: add compatibility to styhead
43279a0 qt3d,qtquick3d: define IOAPI_NO_64
e3deb80 qt6: do not mix bitbake's and shell variables 6dabdc7 Update submodule refs on 'dev' in yocto/meta-qt6 df5ae77 ptests: Install external resource files
6391fcb Update submodule refs on 'dev' in yocto/meta-qt6 f0f4c24 Revert "qtquick3d: add workaround for test build failure" ae443df Update submodule refs on 'dev' in yocto/meta-qt6 e055954 coin: use more memory for the ptest testimage e13760a ptests: Update test environment for non and root user dcd4f6f qtwebengine: add PACKAGECONFIG for x11 dependencies 7c86e03 Update submodule refs on 'dev' in yocto/meta-qt6 4b0b745 qtbase: disable dnslookup for mingw builds 27d6040 Update submodule refs on 'dev' in yocto/meta-qt6 96af7a7 nativesdk-packagegroup-qt6-toolchain-host-addons: Add wayland dependent packages conditionally ca2460b Add vendor to CVE_PRODUCT
b148717 Update submodule refs on 'dev' in yocto/meta-qt6 291bfc8 Update submodule refs on 'dev' in yocto/meta-qt6 f50783d ptest: include only needed files
4c59335 Update submodule refs on 'dev' in yocto/meta-qt6 dbeb327 Update submodule refs on 'dev' in yocto/meta-qt6 89bf14b qtwayland: fix patch fuzz
c23d991 Update submodule refs on 'dev' in yocto/meta-qt6 110dbec qtwayland: make wayland DISTRO_FEATURES a requirement 30ede4c readme: update Yocto support table
68befc5 qtmultimedia: update revision
48790c8 qtpositioning: add geoclue to packageconfig de4eb18 coin: switch one build to scarthgap
7e79a5e coin: don't use nanbield for mingw builds
271a60c qtbase: disable stack protector for mingw
e0ef8e2 qtwayland: fix patch fuzz
5bd6374 Update submodule refs on 'dev' in yocto/meta-qt6 600f22c qtdatavis3d: add feature_check for opengl
e556376 ptest: disable examples build
97ae6a2 qtbase: fix patch fuzz
84a80dd Update submodule refs on 'dev' in yocto/meta-qt6 c174f9a qtbase: don't generate qmake wrapper
fef1539 qtbase: add PACKAGECONFIG for wayland support 185cdd8 Update submodule refs on 'dev' in yocto/meta-qt6 71e791f Update submodule refs on 'dev' in yocto/meta-qt6 82fac6f qtquick3d: add workaround for test build failure f3ca5bd Update submodule refs on 'dev' in yocto/meta-qt6 3c24d5d layer.conf: update LAYERSERIES_COMPAT for scarthgap b8a440f qtbase: prefer system png
a18047e packagegroup: add Qt modules only on supported archs 635948e qtdoc: only add qtpdf to DEPENDS for machines in COMPATIBLE_MACHINE 88c7940 qtwebengine: Remove setting --target option with yocto a36b5a0 libwebp: add workaround for native build
bc941d6 qtwebengine: Add missing dependency on native libevent.pc 5daa561 qtwebengine: Pass OE specific pkg-config-native for host pkg-config 8d3758c packagegroup: fix warning caused by inherit_defer 564f560 coin: update build targets
c0b9c32 ptest: skip non-existing tests
20596ba Update submodule refs on 'dev' in yocto/meta-qt6 d457a6e Add recipe for QtDoc
8fb854d Update submodule refs on 'dev' in yocto/meta-qt6 26e4c0e Update submodule refs on 'dev' in yocto/meta-qt6 7e80a12 webengine: update patch
04f8e6b Update submodule refs on 'dev' in yocto/meta-qt6 5e20524 ptest: better handling for test list
f56893e Add srcrev for QtDoc
7941caa pytest-qt: upgrade to latest version
3bed409 Bump version to 6.8.0
ef6320b Update submodule refs on 'dev' in yocto/meta-qt6 1e336d2 Update submodule refs on 'dev' in yocto/meta-qt6 e56bb1b qtwebengine: update to 118-based
a6c21ee srcrev_update: support for all recipes
13ce6ff qttools: use clang if it is available
0ed7c76 qtinterfaceframework: fix packaging error